### PR TITLE
fix boot on new bios

### DIFF
--- a/config_install_nuc8_bc.plist
+++ b/config_install_nuc8_bc.plist
@@ -52,6 +52,20 @@
 					<key>Replace</key>
 					<data>WERTTQ==</data>
 				</dict>
+				<dict>
+					<key>Comment</key>
+					<string>Fix NUC BIOS DSDT Device(RTC)</string>
+					<key>Disabled</key>
+					<false/>
+					<key>Find</key>
+					<data>
+					oAqTU1RBUwE=
+					</data>
+					<key>Replace</key>
+					<data>
+					oAqRCv8L//8=
+					</data>
+				</dict>
 			</array>
 		</dict>
 		<key>DropTables</key>


### PR DESCRIPTION
starting from bios#64 NUC wont start.
Tested on nuc8i5bek bios#71.
credit to  dongyubin
https://github.com/dongyubin/nuc8i5beh/blob/master/4926EFI/CLOVER/config.plist